### PR TITLE
approval-threshold: lower it daily after three days with no commits

### DIFF
--- a/validate.py
+++ b/validate.py
@@ -101,7 +101,7 @@ def seconds_since_last_commit():
   return int(time.time() - last_commit_ts())
 
 def days_since_last_commit():
-  return int(seconds_since_last_commit() / 60 / 60 / 24) + 5
+  return int(seconds_since_last_commit() / 60 / 60 / 24)
 
 def determine_if_mergeable():
   users = get_users()

--- a/validate.py
+++ b/validate.py
@@ -67,8 +67,10 @@ def get_reviews():
       state = review['state']
 
       print('  %s: %s at %s' % (user, state, commit))
-      if commit != target_commit:
-        continue  # Only accept PR reviews for the most recent commit.
+      if state == 'APPROVED' and commit != target_commit:
+        # Only accept approvals for the most recent commit, but have rejections
+        # last until overridden.
+        continue
 
       if state == 'COMMENTED':
         continue  # Ignore comments.

--- a/validate.py
+++ b/validate.py
@@ -120,10 +120,18 @@ def determine_if_mergeable():
   for user, state in sorted(reviews.items()):
     print ('  %s: %s' % (user, state))
 
-  approval_count = 0
+  approvals = []
+  rejections = []
   for user in users:
-    if reviews.get(user, None) == 'APPROVED':
-      approval_count += 1
+    if user in reviews:
+      review = reviews[user]
+      if review == 'APPROVED':
+        approvals.append(user)
+      else:
+        rejections.append(user)
+
+  if rejections:
+    raise Exception('Rejected by: %s' % (' '.join(rejections)))
 
   required_approvals = len(users)
 
@@ -136,10 +144,10 @@ def determine_if_mergeable():
                                       days_since_last_commit()))
     required_approvals -= approvals_to_skip
 
-  print('Approvals: got %s needed %s' % (
-    approval_count, required_approvals))
+  print('Approvals: got %s (%s) needed %s' % (
+      len(approvals), ' '.join(approvals), required_approvals))
 
-  if approval_count < required_approvals:
+  if len(approvals) < required_approvals:
     raise Exception('Insufficient approval')
 
   print('\nPASS')

--- a/validate.py
+++ b/validate.py
@@ -92,7 +92,8 @@ def get_users():
   return list(sorted(users))
 
 def last_commit_ts():
-  cmd = ['git', 'log', '-1', '--format=%ct']
+  # When was the last commit on master?
+  cmd = ['git', 'log', 'master', '-1', '--format=%ct']
   completed_process = subprocess.run(cmd, stdout=subprocess.PIPE)
   if completed_process.returncode != 0:
     raise Exception(completed_process)


### PR DESCRIPTION
Right now, if someone disappears then we'll have a draw; see #19.  This change is a straight-forward way around this: once three days have passed without a commit, then for every additional day we require one fewer approver.

I'm open to other functions, but I'd like to get something in soon because we're adding a lot of players.

(I think this is probably not what we'll want long term.)