### PR TITLE
approval-threshold: allow changes to go in with majority approval after a day

### DIFF
--- a/validate.py
+++ b/validate.py
@@ -47,9 +47,8 @@ def base_pr_url():
   return 'https://www.jefftk.com/nomic-github/repos/%s/pulls/%s' % (
     get_repo(), get_pr())
 
-def get_author():
-  response = request(base_pr_url())
-  return response.json()['user']['login']
+def get_author(pr_json):
+  return pr_json['user']['login']
 
 def get_reviews():
   target_commit = get_commit()
@@ -91,6 +90,19 @@ def get_users():
         users.add(line.strip())
   return list(sorted(users))
 
+def iso8601_to_ts(iso8601):
+  return int(time.mktime(time.strptime(iso8601, "%Y-%m-%dT%H:%M:%SZ")))
+
+def pr_created_at_ts(pr_json):
+  return iso8601_to_ts(pr_json['created_at'])
+
+def pr_pushed_at_ts(pr_json):
+  return iso8601_to_ts(pr_json['head']['repo']['pushed_at'])
+
+def pr_last_changed_ts(pr_json):
+  return max(pr_created_at_ts(pr_json),
+             pr_pushed_at_ts(pr_json))
+
 def last_commit_ts():
   # When was the last commit on master?
   cmd = ['git', 'log', 'master', '-1', '--format=%ct']
@@ -100,11 +112,11 @@ def last_commit_ts():
 
   return int(completed_process.stdout)
 
-def seconds_since_last_commit():
-  return int(time.time() - last_commit_ts())
+def seconds_since(ts):
+  return int(time.time() - ts)
 
-def days_since_last_commit():
-  return int(seconds_since_last_commit() / 60 / 60 / 24)
+def seconds_to_days(seconds):
+  return int(seconds / 60 / 60 / 24)
 
 def determine_if_mergeable():
   users = get_users()
@@ -112,7 +124,8 @@ def determine_if_mergeable():
   for user in users:
     print('  %s' % user)
 
-  author = get_author()
+  pr_json = request(base_pr_url()).json()
+  author = get_author(pr_json)
   print('\nAuthor: %s' % author)
 
   reviews = get_reviews()
@@ -136,11 +149,21 @@ def determine_if_mergeable():
   if rejections:
     raise Exception('Rejected by: %s' % (' '.join(rejections)))
 
+  days_since_last_changed = seconds_to_days(
+    seconds_since(pr_last_changed_ts(pr_json)))
+  if days_since_last_changed > 1:
+    print('This PR has been sitting for at least a day (%sd) with'
+          ' no rejections.  Considering whether to merge it.' %
+          days_since_last_changed)
+    if len(approvals) > len(users)/2:
+      print('Allowing merge with just a majority.')
+      print('PASS')
+      return
+
   required_approvals = len(users)
 
-  # Allow three days to go by with no commits, but if longer happens then start
   # lowering the threshold for allowing a commit.
-  approvals_to_skip = days_since_last_commit() - 3
+  approvals_to_skip = seconds_to_days(seconds_since(last_commit_ts())) - 3
   if approvals_to_skip > 0:
     print("Skipping up to %s approvals, because it's been %s days"
           " since the last commit." % (approvals_to_skip,


### PR DESCRIPTION
At some point we may want to allow things to go in over someone's rejection: this is not that.  Any player can still reject any PR and stop it.  But if a PR has no rejections, has been approved by a majority of players, and not been updated in the last day, allow it to go in.

Also refactor time-related functions, and avoid fetching the PR json multiple times.