### PR TITLE
Switches to requiring two thirds majority

### DIFF
--- a/validate.py
+++ b/validate.py
@@ -128,7 +128,10 @@ def determine_if_mergeable():
       else:
         rejections.append(user)
 
-  required_approvals = math.ceil(len(users)/3 * 2)
+  if rejections:
+    raise Exception('Rejected by: %s' % (' '.join(rejections)))
+
+  required_approvals = math.ceil(len(users) * 2 / 3)
 
   # Allow three days to go by with no commits, but if longer happens then start
   # lowering the threshold for allowing a commit.

--- a/validate.py
+++ b/validate.py
@@ -1,4 +1,5 @@
 import os
+import math
 import random
 import requests
 import subprocess
@@ -127,10 +128,7 @@ def determine_if_mergeable():
       else:
         rejections.append(user)
 
-  if rejections:
-    raise Exception('Rejected by: %s' % (' '.join(rejections)))
-
-  required_approvals = len(users)
+  required_approvals = math.ceil(len(users)/3 * 2)
 
   # Allow three days to go by with no commits, but if longer happens then start
   # lowering the threshold for allowing a commit.


### PR DESCRIPTION
This PR is being suggested instead of #29. Pull requests are merged in 2/3rds of the players, rounded up, vote in favor of it.

Reasoning: I think getting more pull requests through, with less requirements for each one, is more interesting. So we should lower the required threshold. I think 2/3rds majority is sufficient that everyone can have a say but not so stringent that requests languish forever.