### PR TITLE
Require all PRs to wait 1 day before merging

### DIFF
--- a/players.txt
+++ b/players.txt
@@ -1,3 +1,4 @@
 dchudz
 jeffkaufman
 TheJhyde
+tnelling

--- a/validate.py
+++ b/validate.py
@@ -101,6 +101,10 @@ def seconds_since_last_commit():
 def days_since_last_commit():
   return int(seconds_since_last_commit() / 60 / 60 / 24)
 
+def days_since_pr_created():
+  response = request(base_pr_url())
+  return int(time.time() - response.json()['created_at'])
+
 def determine_if_mergeable():
   users = get_users()
   print('Users:')
@@ -147,6 +151,9 @@ def determine_if_mergeable():
 
   if len(approvals) < required_approvals:
     raise Exception('Insufficient approval')
+
+  if days_since_pr_created() < 1:
+    raise Exception('PR created within last 24 hours')
 
   print('\nPASS')
 


### PR DESCRIPTION
Note that this is from PR creation, not from any subsequent activity.

There's a lot of activity in this game taking place during the day while I'm at work, while I'm generally only able to review said activity after I get home. I'm concerned that with the 2/3 majority rule in effect, I'll have to start rejecting things at work so that I have time to review later, which I don't want to have to do for both in-game and out-of-game reasons.

This obviously should be updated to reflect the refactoring in #37 once that's merged.