### PR TITLE
Allow validate.py to inspect the PR diff

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 # THIS FILE IS OUT OF BOUNDS
 requests>=2.7.0
+unidiff>=0.5.5

--- a/validate.py
+++ b/validate.py
@@ -4,6 +4,7 @@ import random
 import requests
 import subprocess
 import time
+import unidiff
 
 def request(url):
   request_headers = {'User-Agent': 'jeffkaufman/nomic'}
@@ -29,6 +30,12 @@ def get_pr():
 
 def get_commit():
   return os.environ['TRAVIS_PULL_REQUEST_SHA']
+
+def get_pr_diff():
+  # Allow inspecting the changes this PR introduces.
+  response = request('https://patch-diff.githubusercontent.com/raw/%s/pull/%s.diff' % (
+      get_repo(), get_pr()))
+  return unidiff.PatchSet(response.content.decode('utf-8'))
 
 def base_pr_url():
   # This is configured in nginx like:
@@ -101,7 +108,23 @@ def seconds_since_last_commit():
 def days_since_last_commit():
   return int(seconds_since_last_commit() / 60 / 60 / 24)
 
+def print_file_changes(diff):
+  print('\n')
+  for category, category_list in [
+    ('added', diff.added_files),
+    ('modified', diff.modified_files),
+    ('removed', diff.removed_files)]:
+
+    if category_list:
+      print('%s:' % category)
+      for patched_file in category_list:
+        print('  %s' % patched_file.path)
+  print()
+
 def determine_if_mergeable():
+  diff = get_pr_diff()
+  print_file_changes(diff)
+
   users = get_users()
   print('Users:')
   for user in users:


### PR DESCRIPTION
Download the PR diff from github and parse it with unidiff.  For now, just
print out what files are changed.  Future PRs can use this to do things like
have different approval requirements based on what's in the diff.

Example output, for pr #47:

```
added:
  players/TheJhyde/bonuses/initial
  players/dchudz/bonuses/initial
  players/guoruibiao/bonuses/initial
  players/jeffkaufman/bonuses/initial
  players/jmitchell/bonuses/initial
  players/pavellishin/bonuses/initial
  players/sligocki/bonuses/initial
  players/tnelling/bonuses/initial
  players/vesche/bonuses/initial
removed:
  players/TheJhyde
  players/dchudz
  players/guoruibiao
  players/jeffkaufman
  players/jmitchell
  players/pavellishin
  players/sligocki
  players/tnelling
  players/vesche
```