### PR TITLE
Add get_user_points

### DIFF
--- a/validate.py
+++ b/validate.py
@@ -86,6 +86,20 @@ def get_reviews():
 def get_users():
   return list(sorted(os.listdir('players/')))
 
+def get_user_points():
+  points = {}
+
+  for user in get_users():
+    points[user] = 0
+
+    bonus_directory = os.path.join('players', user, 'bonuses')
+    if os.path.isdir(bonus_directory):
+      for named_bonus in os.listdir(bonus_directory):
+        with open(os.path.join(bonus_directory, named_bonus)) as inf:
+          points[user] += int(inf.read())
+
+  return points
+
 def last_commit_ts():
   # When was the last commit on master?
   cmd = ['git', 'log', 'master', '-1', '--format=%ct']
@@ -101,7 +115,14 @@ def seconds_since_last_commit():
 def days_since_last_commit():
   return int(seconds_since_last_commit() / 60 / 60 / 24)
 
+def print_points():
+  print('Points:')
+  for user, user_points in get_user_points().items():
+    print('  %s: %s' % (user, user_points))
+
 def determine_if_mergeable():
+  print_points()
+
   users = get_users()
   print('Users:')
   for user in users:
@@ -151,6 +172,8 @@ def determine_if_mergeable():
   print('\nPASS')
 
 def determine_if_winner():
+  print_points()
+
   users = get_users()
   for user in users:
     if random.random() < 0.0001:


### PR DESCRIPTION
Add a function to pull points out of the points files, and print them.  Still
doesn't make points do anything.  Pulled out of #33 to make things easier to
review.

During review of #33 people noted that you might be able to make this function
fail with an Exception saying that you win, which might not be caught earlier
because get_user_points would only be called in determine_if_winner, which
isn't called on PR validation.  One way to handle this would be to rewrite the
code defensively, catching every potential issue (something not being a
directory, contents of the file not being an int, etc), but this PR takes a
much simpler (and easier to trust approach) of just additionally running
get_user_points on PR validation.  This way, if there's something wrong with
the environment the PR will fail in validation and not be mergeable.

Depends on #47, compatible with #33