### PR TITLE
winning: make someone's chance of winning proportional to points

### DIFF
--- a/validate.py
+++ b/validate.py
@@ -290,10 +290,9 @@ def determine_if_mergeable():
 def determine_if_winner():
   print_points()
 
-  users = get_users()
-  for user in users:
-    if random.random() < 0.0001:
-      raise RuntimeException('%s wins!' % user)
+  for user, user_points in get_user_points().items():
+    if random.random() < 0.00001 * user_points:
+      raise Exception('%s wins!' % user)
   print('The game continues.')
 
 def start():


### PR DESCRIPTION
Currently, each player had a 0.01% chance of winning per PR merged to master.

This PR changes chances to be proportional to points.  Currently points are:

```
  jeffkaufman: 17
  pavellishin: 11
  shaunagm:    10
  sligocki:    10
  tnelling:    12
  vesche:      10
```

So this PR, today, would give chances of winning of:

```
  jeffkaufman: 0.017%
  pavellishin: 0.011%
  shaunagm:    0.010%
  sligocki:    0.010%
  tnelling:    0.012%
  vesche:      0.010%
```

Also fix a bug where I wrote `RuntimeException` instead of `Exception`.  Too much Java!

Here's what it looks like if you run it until it hits someone:

```
./run.sh
TRAVIS_REPO_SLUG='jeffkaufman/nomic'
TRAVIS_PULL_REQUEST='false'
TRAVIS_PULL_REQUEST_SHA=''

validate.py:
Points:
  jeffkaufman: 17
  pavellishin: 11
  shaunagm: 10
  sligocki: 10
  tnelling: 12
  vesche: 10
Traceback (most recent call last):
  File "validate.py", line 305, in <module>
    start()
  File "validate.py", line 300, in start
    determine_if_winner()
  File "validate.py", line 295, in determine_if_winner
    raise Exception('%s wins!' % user)
Exception: tnelling wins!
```