### PR TITLE
Refactor files

### DIFF
--- a/pull_request.py
+++ b/pull_request.py
@@ -4,14 +4,14 @@ import util
 
 class PullRequest:
   def __init__(self, repo, pr_number, target_commit, users):
-    self.repo_ = repo
-    self.pr_number_ = pr_number
-    self.target_commit_ = target_commit
-    self.users_ = users
+    self._repo = repo
+    self._pr_number = pr_number
+    self._target_commit = target_commit
+    self._users = users
 
-    self.pr_json_ = util.request(self.base_pr_url_()).json()
+    self._pr_json = util.request(self._base_pr_url()).json()
 
-    self.reviews = self.calculate_reviews_()
+    self.reviews = self._calculate_reviews()
     if self.author() in users:
       self.reviews[self.author()] = 'APPROVED'
 
@@ -30,10 +30,10 @@ class PullRequest:
                               and user not in self.rejections ]
 
   def created_at_ts(self):
-    return util.iso8601_to_ts(self.pr_json_['created_at'])
+    return util.iso8601_to_ts(self._pr_json['created_at'])
 
   def pushed_at_ts(self):
-    return util.iso8601_to_ts(self.pr_json_['head']['repo']['pushed_at'])
+    return util.iso8601_to_ts(self._pr_json['head']['repo']['pushed_at'])
 
   def last_changed_ts(self):
     return max(self.created_at_ts(),
@@ -48,8 +48,8 @@ class PullRequest:
   def days_since_changed(self):
     return util.days_since(self.last_changed_ts())
 
-  def calculate_reviews_(self):
-    base_url = '%s/reviews' % self.base_pr_url_()
+  def _calculate_reviews(self):
+    base_url = '%s/reviews' % self._base_pr_url()
     url = base_url
     reviews = {}
   
@@ -61,7 +61,7 @@ class PullRequest:
         commit = review['commit_id']
         state = review['state']
   
-        if state == 'APPROVED' and commit != self.target_commit_:
+        if state == 'APPROVED' and commit != self._target_commit:
           # An approval clears out any past rejections from a user.
           try:
             del reviews[user]
@@ -87,7 +87,7 @@ class PullRequest:
       else:
         return reviews
 
-  def base_pr_url_(self):
+  def _base_pr_url(self):
     # This is configured in nginx like:
     #
     # proxy_cache_path
@@ -124,15 +124,15 @@ class PullRequest:
     # them or make the dashboard only gather reviews for PRs in the "reviewme"
     # state.
     return 'https://www.jefftk.com/nomic-github/repos/%s/pulls/%s' % (
-      self.repo_, self.pr_number_)
+      self._repo, self._pr_number)
 
   def diff(self):
     response = util.request('https://patch-diff.githubusercontent.com/raw/%s/pull/%s.diff' % (
-        self.repo_, self.pr_number_))
+        self._repo, self._pr_number))
     return unidiff.PatchSet(response.content.decode('utf-8'))
 
   def author(self):
-    return self.pr_json_['user']['login']
+    return self._pr_json['user']['login']
 
 
 

--- a/pull_request.py
+++ b/pull_request.py
@@ -1,0 +1,138 @@
+import unidiff
+
+import util
+
+class PullRequest:
+  def __init__(self, repo, pr_number, target_commit, users):
+    self.repo_ = repo
+    self.pr_number_ = pr_number
+    self.target_commit_ = target_commit
+    self.users_ = users
+
+    self.pr_json_ = util.request(self.base_pr_url_()).json()
+
+    self.reviews = self.calculate_reviews_()
+    if self.author() in users:
+      self.reviews[self.author()] = 'APPROVED'
+
+    self.approvals = []
+    self.rejections = []
+    for user in users:
+      if user in self.reviews:
+        review = self.reviews[user]
+        if review == 'APPROVED':
+          self.approvals.append(user)
+        else:
+          self.rejections.append(user)
+
+    self.non_participants = [ user for user in users
+                              if user not in self.approvals
+                              and user not in self.rejections ]
+
+  def created_at_ts(self):
+    return util.iso8601_to_ts(self.pr_json_['created_at'])
+
+  def pushed_at_ts(self):
+    return util.iso8601_to_ts(self.pr_json_['head']['repo']['pushed_at'])
+
+  def last_changed_ts(self):
+    return max(self.created_at_ts(),
+               self.pushed_at_ts())
+
+  def days_since_created(self):
+    return util.days_since(self.created_at_ts())
+
+  def days_since_pushed(self):
+    return util.days_since(self.pushed_at_ts())
+
+  def days_since_changed(self):
+    return util.days_since(self.last_changed_ts())
+
+  def calculate_reviews_(self):
+    base_url = '%s/reviews' % self.base_pr_url_()
+    url = base_url
+    reviews = {}
+  
+    while True:
+      response = util.request(url)
+  
+      for review in response.json():
+        user = review['user']['login']
+        commit = review['commit_id']
+        state = review['state']
+  
+        if state == 'APPROVED' and commit != self.target_commit_:
+          # An approval clears out any past rejections from a user.
+          try:
+            del reviews[user]
+          except KeyError:
+            pass # No past rejections for this user.
+  
+          # Only accept approvals for the most recent commit, but have rejections
+          # last until overridden.
+          continue
+  
+        if state == 'COMMENTED':
+          continue  # Ignore comments.
+  
+        reviews[user] = state
+  
+      if 'next' in response.links:
+        # This unfortunately points to GitHub, and not to the rate-limit-avoiding
+        # proxy.  Pull off the query string (ex: "?page=3") and append that to
+        # our url that goes via the proxy.
+        next_url = response.links['next']['url']
+        github_api_path, query_string = next_url.split('?')
+        url = '%s?%s' % (base_url, query_string)
+      else:
+        return reviews
+
+  def base_pr_url_(self):
+    # This is configured in nginx like:
+    #
+    # proxy_cache_path
+    #     /tmp/github-proxy
+    #     levels=1:2
+    #     keys_zone=github-proxy:1m
+    #     max_size=100m;
+    #
+    # server {
+    #   ...
+    #   location /nomic-github/repos/jeffkaufman/nomic {
+    #     proxy_cache github-proxy;
+    #     proxy_ignore_headers Cache-Control Vary;
+    #     proxy_cache_valid any 1m;
+    #     proxy_pass https://api.github.com/repos/jeffkaufman/nomic;
+    #     proxy_set_header
+    #         Authorization
+    #         "Basic [base64 of 'username:token']";
+    #   }
+    #
+    # Where the token is a github personal access token:
+    #   https://github.com/settings/tokens
+    #
+    # There's an API limit of 60/hr per IP by default, and 5000/hr by
+    # user, and we need the higher limit.
+    #
+    # Responses are cached for one minute by this proxy.  The caching is
+    # optional, but now that https:/www.jefftk.com/nomic is available and
+    # world-accessible it could potentilly get hit by substantial traffic.  At a
+    # 60s cache and 5k/hr limit we can have 83 GitHub API requests per page
+    # render and not go down.  As of 2018-01-18 there are eight open PRs, each
+    # of which needs a request to get reviews, so we're ok by a factor of 10.  If
+    # we have a lot of old open PRs we don't care about we could either close
+    # them or make the dashboard only gather reviews for PRs in the "reviewme"
+    # state.
+    return 'https://www.jefftk.com/nomic-github/repos/%s/pulls/%s' % (
+      self.repo_, self.pr_number_)
+
+  def diff(self):
+    response = util.request('https://patch-diff.githubusercontent.com/raw/%s/pull/%s.diff' % (
+        self.repo_, self.pr_number_))
+    return unidiff.PatchSet(response.content.decode('utf-8'))
+
+  def author(self):
+    return self.pr_json_['user']['login']
+
+
+

--- a/pull_request.py
+++ b/pull_request.py
@@ -11,16 +11,18 @@ class PullRequest:
 
     self._pr_json = util.request(self._base_pr_url()).json()
 
+    # Hash from user names to booleans representing whether the user has
+    # approved or rejected the PR.
     self.reviews = self._calculate_reviews()
+
     if self.author() in users:
-      self.reviews[self.author()] = 'APPROVED'
+      self.reviews[self.author()] = True
 
     self.approvals = []
     self.rejections = []
     for user in users:
       if user in self.reviews:
-        review = self.reviews[user]
-        if review == 'APPROVED':
+        if self.reviews[user]:
           self.approvals.append(user)
         else:
           self.rejections.append(user)
@@ -75,7 +77,7 @@ class PullRequest:
         if state == 'COMMENTED':
           continue  # Ignore comments.
   
-        reviews[user] = state
+        reviews[user] = (state == 'APPROVED')
   
       if 'next' in response.links:
         # This unfortunately points to GitHub, and not to the rate-limit-avoiding

--- a/util.py
+++ b/util.py
@@ -1,0 +1,48 @@
+import os
+import requests
+import subprocess
+import time
+
+def request(url):
+  request_headers = {'User-Agent': 'jeffkaufman/nomic'}
+  response = requests.get(url, headers=request_headers)
+
+  for header in ['X-RateLimit-Limit',
+                 'X-RateLimit-Remaining',
+                 'X-RateLimit-Reset']:
+    if header in response.headers:
+      print('    > %s: %s' % (header, response.headers[header]))
+
+  if response.status_code != 200:
+    print('   > %s' % response.content)
+
+  response.raise_for_status()
+  return response
+
+def iso8601_to_ts(iso8601):
+  return int(time.mktime(time.strptime(iso8601, "%Y-%m-%dT%H:%M:%SZ")))
+
+def users():
+  return list(sorted(os.listdir('players/')))
+
+def last_commit_ts():
+  # When was the last commit on master?
+  cmd = ['git', 'log', 'master', '-1', '--format=%ct']
+  completed_process = subprocess.run(cmd, stdout=subprocess.PIPE)
+  if completed_process.returncode != 0:
+    raise Exception(completed_process)
+
+  return int(completed_process.stdout)
+
+def seconds_since(ts):
+  return int(time.time() - ts)
+
+def seconds_to_days(seconds):
+  return int(seconds / 60 / 60 / 24)
+
+def days_since(ts):
+  return seconds_to_days(seconds_since(ts))
+
+def days_since_last_commit():
+  return days_since(last_commit_ts())
+

--- a/validate.py
+++ b/validate.py
@@ -2,134 +2,15 @@ import os
 import math
 import random
 import re
-import requests
 import subprocess
-import time
-import unidiff
 
-def request(url):
-  request_headers = {'User-Agent': 'jeffkaufman/nomic'}
-  response = requests.get(url, headers=request_headers)
-
-  for header in ['X-RateLimit-Limit',
-                 'X-RateLimit-Remaining',
-                 'X-RateLimit-Reset']:
-    if header in response.headers:
-      print('    > %s: %s' % (header, response.headers[header]))
-
-  if response.status_code != 200:
-    print('   > %s' % response.content)
-
-  response.raise_for_status()
-  return response
-
-def get_repo():
-  return os.environ['TRAVIS_REPO_SLUG']
-
-def get_pr():
-  return os.environ['TRAVIS_PULL_REQUEST']
-
-def get_commit():
-  return os.environ['TRAVIS_PULL_REQUEST_SHA']
-
-def get_pr_diff():
-  # Allow inspecting the changes this PR introduces.
-  response = request('https://patch-diff.githubusercontent.com/raw/%s/pull/%s.diff' % (
-      get_repo(), get_pr()))
-  return unidiff.PatchSet(response.content.decode('utf-8'))
-
-def base_pr_url():
-  # This is configured in nginx like:
-  #
-  # proxy_cache_path
-  #     /tmp/github-proxy
-  #     levels=1:2
-  #     keys_zone=github-proxy:1m
-  #     max_size=100m;
-  #
-  # server {
-  #   ...
-  #   location /nomic-github/repos/jeffkaufman/nomic {
-  #     proxy_cache github-proxy;
-  #     proxy_ignore_headers Cache-Control Vary;
-  #     proxy_cache_valid any 1m;
-  #     proxy_pass https://api.github.com/repos/jeffkaufman/nomic;
-  #     proxy_set_header
-  #         Authorization
-  #         "Basic [base64 of 'username:token']";
-  #   }
-  #
-  # Where the token is a github personal access token:
-  #   https://github.com/settings/tokens
-  #
-  # There's an API limit of 60/hr per IP by default, and 5000/hr by
-  # user, and we need the higher limit.
-  #
-  # Responses are cached for one minute by this proxy.  The caching is
-  # optional, but now that https:/www.jefftk.com/nomic is available and
-  # world-accessible it could potentilly get hit by substantial traffic.  At a
-  # 60s cache and 5k/hr limit we can have 83 GitHub API requests per page
-  # render and not go down.  As of 2018-01-18 there are eight open PRs, each
-  # of which needs a request to get reviews, so we're ok by a factor of 10.  If
-  # we have a lot of old open PRs we don't care about we could either close
-  # them or make the dashboard only gather reviews for PRs in the "reviewme"
-  # state.
-  return 'https://www.jefftk.com/nomic-github/repos/%s/pulls/%s' % (
-    get_repo(), get_pr())
-
-def get_author(pr_json):
-  return pr_json['user']['login']
-
-def get_reviews():
-  target_commit = get_commit()
-  print('Considering reviews at commit %s' % target_commit)
-
-  base_url = '%s/reviews' % base_pr_url()
-  url = base_url
-  reviews = {}
-
-  while True:
-    response = request(url)
-
-    for review in response.json():
-      user = review['user']['login']
-      commit = review['commit_id']
-      state = review['state']
-
-      print('  %s: %s at %s' % (user, state, commit))
-      if state == 'APPROVED' and commit != target_commit:
-        # An approval clears out any past rejections from a user.
-        try:
-          del reviews[user]
-        except KeyError:
-          pass # No past rejections for this user.
-
-        # Only accept approvals for the most recent commit, but have rejections
-        # last until overridden.
-        continue
-
-      if state == 'COMMENTED':
-        continue  # Ignore comments.
-
-      reviews[user] = state
-
-    if 'next' in response.links:
-      # This unfortunately points to GitHub, and not to the rate-limit-avoiding
-      # proxy.  Pull off the query string (ex: "?page=3") and append that to
-      # our url that goes via the proxy.
-      next_url = response.links['next']['url']
-      github_api_path, query_string = next_url.split('?')
-      url = '%s?%s' % (base_url, query_string)
-    else:
-      return reviews
-
-def get_users():
-  return list(sorted(os.listdir('players/')))
+import util
+import pull_request
 
 def get_user_points():
   points = {}
 
-  for user in get_users():
+  for user in util.users():
     points[user] = 0
 
     bonus_directory = os.path.join('players', user, 'bonuses')
@@ -163,49 +44,19 @@ def get_user_points():
 
   return points
 
-def iso8601_to_ts(iso8601):
-  return int(time.mktime(time.strptime(iso8601, "%Y-%m-%dT%H:%M:%SZ")))
-
-def pr_created_at_ts(pr_json):
-  return iso8601_to_ts(pr_json['created_at'])
-
-def pr_pushed_at_ts(pr_json):
-  return iso8601_to_ts(pr_json['head']['repo']['pushed_at'])
-
-def pr_last_changed_ts(pr_json):
-  return max(pr_created_at_ts(pr_json),
-             pr_pushed_at_ts(pr_json))
-
-def last_commit_ts():
-  # When was the last commit on master?
-  cmd = ['git', 'log', 'master', '-1', '--format=%ct']
-  completed_process = subprocess.run(cmd, stdout=subprocess.PIPE)
-  if completed_process.returncode != 0:
-    raise Exception(completed_process)
-
-  return int(completed_process.stdout)
-
-def seconds_since(ts):
-  return int(time.time() - ts)
-
-def seconds_to_days(seconds):
-  return int(seconds / 60 / 60 / 24)
-
 def print_points():
   print('Points:')
   for user, user_points in get_user_points().items():
     print('  %s: %s' % (user, user_points))
 
-def days_since(ts):
-  return seconds_to_days(seconds_since(ts))
+def print_users():
+  users = util.users()
+  print('Users:')
+  for user in users:
+    print('  %s' % user)
 
-def days_since_last_commit():
-  return days_since(last_commit_ts())
-
-def days_since_pr_created(pr_json):
-  return days_since(pr_created_at_ts(pr_json))
-
-def print_file_changes(diff):
+def print_file_changes(pr):
+  diff = pr.diff()
   print('\n')
   for category, category_list in [
     ('added', diff.added_files),
@@ -216,9 +67,9 @@ def print_file_changes(diff):
       print('%s:' % category)
       for patched_file in category_list:
         print('  %s' % patched_file.path)
-  print()
+        print()
 
-def mergeable_as_points_transfer(diff, approvals, rejections):
+def mergeable_as_points_transfer(pr):
   # If a PR only moves points around by the creation of new bonus files, has
   # been approved by every player losing points, reduces the total number of
   # points, allow it.
@@ -237,6 +88,7 @@ def mergeable_as_points_transfer(diff, approvals, rejections):
 
   print('\nConsidering whether this can be merged as a points transfer:')
 
+  diff = pr.diff()
   if diff.modified_files or diff.removed_files:
     raise Exception('All file changes must be additions')
 
@@ -283,7 +135,7 @@ def mergeable_as_points_transfer(diff, approvals, rejections):
     points_change = int(actual_file_delta)
 
     if points_change < 0:
-      if points_user not in approvals:
+      if points_user not in pr.approvals:
         raise Exception('Taking %s points from %s requires their approval.' % (
             abs(points_change), points_user))
 
@@ -295,79 +147,53 @@ def mergeable_as_points_transfer(diff, approvals, rejections):
   # Returning without an exception is how we indicate success.
   print('  yes')
 
-def determine_if_mergeable():
-  print_points()
-
-  diff = get_pr_diff()
-  print_file_changes(diff)
-
-  users = get_users()
-  print('Users:')
-  for user in users:
-    print('  %s' % user)
-
-  pr_json = request(base_pr_url()).json()
-  author = get_author(pr_json)
-  print('\nAuthor: %s' % author)
-
-  reviews = get_reviews()
-  if author in users:
-    reviews[author] = 'APPROVED'
+def print_status(pr):
+  print('\nAuthor: %s' % pr.author())
 
   print('\nReviews:')
-  for user, state in sorted(reviews.items()):
+  for user, state in sorted(pr.reviews.items()):
     print ('  %s: %s' % (user, state))
 
-  approvals = []
-  rejections = []
-  for user in users:
-    if user in reviews:
-      review = reviews[user]
-      if review == 'APPROVED':
-        approvals.append(user)
-      else:
-        rejections.append(user)
+  print('Approvals: %s - %s' % (len(pr.approvals), ' '.join(pr.approvals)))
+  print('Rejections: %s - %s' %(len(pr.rejections), ' '.join(pr.rejections)))
+  print('Non-participants: %s - %s' %(len(pr.non_participants), ' '.join(pr.non_participants)))
+
+  print_file_changes(pr)
+
+def determine_if_mergeable(pr):
+  print_points()
+  print_status(pr)
 
   try:
-    mergeable_as_points_transfer(diff, approvals, rejections)
+    mergeable_as_points_transfer(pr)
   except Exception as e:
     print("Doesn't meet requirements for points transfer: %s" % e)
   else:
     print('Meets requirements for points transfer.  PASS')
     return
 
-  non_participants = [ user for user in users
-                       if user not in approvals
-                       and user not in rejections ]
-
-  print('Approvals: %s - %s' % (len(approvals), ' '.join(approvals)))
-  print('Rejections: %s - %s' %(len(rejections), ' '.join(rejections)))
-  print('Non-participants: %s - %s' %(len(non_participants), ' '.join(non_participants)))
-
-  if rejections:
-    raise Exception('Rejected by: %s' % (' '.join(rejections)))
-
-  days_since_last_changed = days_since(pr_last_changed_ts(pr_json))
+  if pr.rejections:
+    raise Exception('Rejected by: %s' % (' '.join(pr.rejections)))
 
   print('FYI: this PR has been sitting for %s days' % (
-      days_since_last_changed))
+      pr.days_since_changed()))
 
-  required_approvals = math.ceil(len(users) * 2 / 3)
+  required_approvals = math.ceil(len(util.users()) * 2 / 3)
 
   # Allow three days to go by with no commits, but if longer happens then start
   # lowering the threshold for allowing a commit.
-  approvals_to_skip = days_since_last_commit() - 3
+  approvals_to_skip = util.days_since_last_commit() - 3
   if approvals_to_skip > 0:
     print("Skipping up to %s approvals, because it's been %s days"
           " since the last commit." % (approvals_to_skip,
-                                      days_since_last_commit()))
+                                       util.days_since_last_commit()))
     required_approvals -= approvals_to_skip
 
-  if len(approvals) < required_approvals:
-    raise Exception('Insufficient approval: got %s out of %s required approvals' % (len(approvals), required_approvals))
+  if len(pr.approvals) < required_approvals:
+    raise Exception('Insufficient approval: got %s out of %s required approvals' % (len(pr.approvals), required_approvals))
 
   # Don't allow PRs to be merged the day they're created unless they pass unanimously
-  if (len(approvals) < len(users)) and (days_since_pr_created(pr_json) < 1):
+  if (len(pr.approvals) < len(util.users())) and (pr.days_since_created() < 1):
     raise Exception('PR created within last 24 hours does not have unanimous approval.')
 
   print('\nPASS')
@@ -381,10 +207,18 @@ def determine_if_winner():
   print('The game continues.')
 
 def start():
-  if get_pr() == 'false':
+  travis_pull_request = os.environ['TRAVIS_PULL_REQUEST']
+
+  if travis_pull_request == 'false':
     determine_if_winner()
   else:
-    determine_if_mergeable()
+    target_commit = os.environ['TRAVIS_PULL_REQUEST_SHA']
+    repo_slug = os.environ['TRAVIS_REPO_SLUG']
+    determine_if_mergeable(pull_request.PullRequest(
+        repo=repo_slug,
+        pr_number=travis_pull_request,
+        target_commit=target_commit,
+        users=util.users()))
 
 if __name__ == '__main__':
   start()

--- a/validate.py
+++ b/validate.py
@@ -67,7 +67,7 @@ def print_file_changes(pr):
       print('%s:' % category)
       for patched_file in category_list:
         print('  %s' % patched_file.path)
-        print()
+  print()
 
 def mergeable_as_points_transfer(pr):
   # If a PR only moves points around by the creation of new bonus files, has
@@ -158,6 +158,9 @@ def print_status(pr):
   print('Rejections: %s - %s' %(len(pr.rejections), ' '.join(pr.rejections)))
   print('Non-participants: %s - %s' %(len(pr.non_participants), ' '.join(pr.non_participants)))
 
+  print('\nFYI: this PR has been sitting for %s days' % (
+      pr.days_since_changed()))
+
   print_file_changes(pr)
 
 def determine_if_mergeable(pr):
@@ -174,9 +177,6 @@ def determine_if_mergeable(pr):
 
   if pr.rejections:
     raise Exception('Rejected by: %s' % (' '.join(pr.rejections)))
-
-  print('FYI: this PR has been sitting for %s days' % (
-      pr.days_since_changed()))
 
   required_approvals = math.ceil(len(util.users()) * 2 / 3)
 


### PR DESCRIPTION
As @tnelling noted in #49, `validate.py` has gotten really large and confusing.
So, refactor time!

* Create a `PullRequest` object that has all the state needed to evaluate a PR,
  and put it in its own file.

* Create a util module, and move things like time parsing and net requests over
  there.

* What's left in `validate.py` is stuff around printing, determination of a
  winner, and determining whether a PR is acceptable to merge.

* All variables in `PullRequest` ending in an underscore are private, and should
  only be used from within `PullRequest`.

The only behavior change is that I removed a small amount of printing from the
review fetching code, because I wanted all the printing to be in `validate.py`.
Everything else is just moving things around, with some renaming.

Detailed summary:

* `pr_json` is now `pr.pr_json_`
* `get_repo()` is now `pr.repo_`
* `get_pr_number()` is now `pr.pr_number_`
* `get_commit()` is now `pr.target_commit`
* `base_pr_url()` is now `pr.base_pr_url_()`
* review fetching and parsing is in `PullRequest`, under `calculate_reviews_()`
* determining approvals, rejections, and non_participants is now in the
  `PullRequest` constructor
* `pr_created_at_ts()` is now `pr.created_at_ts()`
* `pr_pushed_at_ts()` is now `pr.pushed_at_ts()`
* `pr_last_changed_ts()` is now `pr.last_changed_ts()`
* `days_since_pr_created()` is now `pr.days_since_created()`
* `last_commit_ts()` is now `util.last_commit_ts()`
* `days_since_last_commit()` is `now util.days_since_last_commit()`
* `seconds_since()` is now `util.seconds_since()`
* `iso8601_to_ts()` is now `util.iso8601_to_ts()`
* `get_users()` is `now util.users()`

I had initially planned to include something in this refactor that would let us
break `determine_if_mergeable()` up into tiny cascading files that each clearly
explained when they would cause a PR to be accepted or rejected, but there's
enough in this PR already.