### PR TITLE
random: don't bias towards earlier users

### DIFF
--- a/validate.py
+++ b/validate.py
@@ -117,7 +117,7 @@ def determine_if_winner():
   rnd = random.random()
   points_so_far = 0
   for user, user_points in util.get_user_points().items():
-    if rnd < 0.00001 * user_points + points_so_far:
+    if rnd < 0.00001 * (user_points + points_so_far):
       raise Exception('%s wins!' % user)
     points_so_far += user_points
 

--- a/validate.py
+++ b/validate.py
@@ -94,9 +94,33 @@ def determine_if_mergeable(pr):
 def determine_if_winner():
   print_points()
 
+  # Pick a winner at random with a single random number.  We divide the number
+  # line up like:
+  #
+  # [ a_points | b_points | c_points | ... everything else ... ]
+  #
+  # and then we choose a place on the number line randomly:
+  #
+  # [ a_points | b_points | c_points | ... everything else ... ]
+  #                          ^
+  #
+  # or:
+  # [ a_points | b_points | c_points | ... everything else ... ]
+  #                                       ^
+  # You can think of this as assigning a range to each player:
+  #
+  #   A wins if random is [0, a_points)
+  #   B wins if random is [a_points, a_points + b_points)
+  #   C wins if random is [a_points + b_points, a_points + b_points + c_points)
+  #   no one wins if random is [a_points + b_points + c_points, 1)
+
+  rnd = random.random()
+  points_so_far = 0
   for user, user_points in util.get_user_points().items():
-    if random.random() < 0.00001 * user_points:
+    if rnd < 0.00001 * user_points + points_so_far:
       raise Exception('%s wins!' % user)
+    points_so_far += user_points
+
   print('The game continues.')
 
 def start():


### PR DESCRIPTION
Currently our random selection has a bias towards earlier users.  For each user we generate a random number and see if their total is below it, so there's an edge to being earlier.  This edge gets larger as points grow.  For example, if we had two players each with 50k points, the first player would win 50% of the time, while the second would only win 50% of remainder, or 25% of the time.

Switch to picking a single random number and seeing which, if any, player that corresponds to.  Now both players would win 50% of the time.

Testing this, with the points scalar at 0.001 instead of 0.00001 to not take so long, I see:

```
   8 Exception: pavellishin wins!
  10 Exception: csvoss wins!
  13 Exception: jeffkaufman wins!
  14 Exception: tnelling wins!
 955 The game continues.
```

which seems reasonable given our current points.