### PR TITLE
start using reproducible random numbers

### DIFF
--- a/validate.py
+++ b/validate.py
@@ -94,9 +94,33 @@ def determine_if_mergeable(pr):
 def determine_if_winner():
   print_points()
 
+  # Pick a winner at random with a single random number.  We divide the number
+  # line up like:
+  #
+  # [ a_points | b_points | c_points | ... everything else ... ]
+  #
+  # and then we choose a place on the number line randomly:
+  #
+  # [ a_points | b_points | c_points | ... everything else ... ]
+  #                          ^
+  #
+  # or:
+  # [ a_points | b_points | c_points | ... everything else ... ]
+  #                                       ^
+  # You can think of this as assigning a range to each player:
+  #
+  #   A wins if random is [0, a_points)
+  #   B wins if random is [a_points, a_points + b_points)
+  #   C wins if random is [a_points + b_points, a_points + b_points + c_points)
+  #   no one wins if random is [a_points + b_points + c_points, 1)
+
+  rnd = random.random()
+  points_so_far = 0
   for user, user_points in util.get_user_points().items():
-    if random.random() < 0.00001 * user_points:
+    if rnd < 0.00001 * user_points + points_so_far:
       raise Exception('%s wins!' % user)
+    points_so_far += user_points
+
   print('The game continues.')
 
 def start():

--- a/validate.py
+++ b/validate.py
@@ -1,5 +1,4 @@
 import os
-import random
 import runpy
 import copy
 
@@ -114,7 +113,7 @@ def determine_if_winner():
   #   C wins if random is [a_points + b_points, a_points + b_points + c_points)
   #   no one wins if random is [a_points + b_points + c_points, 1)
 
-  rnd = random.random()
+  rnd = util.random()
   points_so_far = 0
   for user, user_points in util.get_user_points().items():
     if rnd < 0.00001 * user_points + points_so_far:


### PR DESCRIPTION
Currently we have Travis running random.random() to determine if someone has won.  This of course gives different values each time you run it.  This is basically fine, but it would be better to use a hash of something that (a) we all can verify and (b) we can't predict.  Then we don't have to trust Travis or worry about people re-running Travis builds.

This PR switches us to using the hash of the merge commit as our source of randomness.  We only get one of these, so this depends on the fix in #97.

As a sanity check on the math I generated the random numbers corresponding to the 194 commits we have on master, to see that it really does give the full range of values: 

<img width="584" alt="screen shot 2019-02-04 at 10 04 53 am" src="https://user-images.githubusercontent.com/262566/52219702-322e0800-286b-11e9-974b-4a2de74c56a3.png">

https://docs.google.com/spreadsheets/d/1PwRT8q5OdjWsZsGTHwZSlw4zCjy2yaUvKi0UX--7Wtk/edit#gid=0