### PR TITLE
factor out get_new_bonuses_or_raise

### DIFF
--- a/pull_request.py
+++ b/pull_request.py
@@ -232,7 +232,6 @@ class PullRequest:
     if diff.modified_files or diff.removed_files:
       raise Exception('All file changes must be additions')
 
-
     bonuses: List[Tuple[str, str, int]] = []
 
     for added_file in diff.added_files:

--- a/pull_request.py
+++ b/pull_request.py
@@ -271,8 +271,10 @@ class PullRequest:
         raise Exception('File delta missing initial + for addition: %s' %
                         file_delta_line)
 
-      # If this isn't an int, then it raises and the PR isn't mergeable
-      points_change = int(actual_file_delta)
+      try:
+        points_change = int(actual_file_delta)
+      except ValueError:
+        raise Exception("File should contain a single integer.")
 
       bonuses.append((points_user, bonus_name, points_change))
 

--- a/pull_request.py
+++ b/pull_request.py
@@ -221,7 +221,7 @@ class PullRequest:
     return unidiff.PatchSet(response.content.decode('utf-8'))
 
   def get_new_bonuses_or_raise(self) -> List[Tuple[str, str, int]]:
-    # If this PR represents adding a new bonus files, return details
+    # If this PR represents adding only new bonus files, return details
     # about the files.  Otherwise raise an exception explaining how the diff
     # doesn't qualify.
     #
@@ -273,7 +273,7 @@ class PullRequest:
 
       try:
         points_change = int(actual_file_delta)
-      except ValueError:
+      except Exception:
         raise Exception("File should contain a single integer.")
 
       bonuses.append((points_user, bonus_name, points_change))

--- a/pull_request.py
+++ b/pull_request.py
@@ -220,6 +220,68 @@ class PullRequest:
         self._repo, self._pr_number))
     return unidiff.PatchSet(response.content.decode('utf-8'))
 
+  def get_new_bonuses_or_raise(self) -> List[Tuple[str, str, int]]:
+    # If this PR represents adding a new bonus files, return details
+    # about the files.  Otherwise raise an exception explaining how the diff
+    # doesn't qualify.
+    #
+    # Returns [(bonus_1_user, bonus_1_name, bonus_1_value),
+    #          (bonus_2_user, bonus_2_name, bonus_2_value), ... ]
+
+    diff = self.diff()
+    if diff.modified_files or diff.removed_files:
+      raise Exception('All file changes must be additions')
+
+
+    bonuses: List[Tuple[str, str, int]] = []
+
+    for added_file in diff.added_files:
+      s_players, points_user, s_bonuses, bonus_name =  added_file.path.split('/')
+      if s_players != 'players' or s_bonuses != 'bonuses':
+        raise Exception('Added file %s is not a bonus file' % added_file)
+
+      (diff_invocation_line, file_mode_line, _, removed_file_line,
+       added_file_line, patch_location_line, file_delta_line,
+       empty_line) = str(added_file).split('\n')
+
+      if diff_invocation_line != 'diff --git a/%s b/%s' % (
+          added_file.path, added_file.path):
+        raise Exception('Unexpected diff invocation: %s' % diff_invocation_line)
+
+      if file_mode_line != 'new file mode 100644':
+        raise Exception('File added with incorrect mode: %s' % file_mode_line)
+
+      if removed_file_line != '--- /dev/null':
+        raise Exception(
+          'Diff format makes no sense: added files should say they are from /dev/null')
+
+      if added_file_line != '+++ b/%s' % added_file.path:
+        raise Exception('Something wrong with file adding line: file is '
+                        '%s but got %s' % (added_file.path, added_file_line))
+
+      if patch_location_line != '@@ -0,0 +1,1 @@':
+        raise Exception('Patch location makes no sense: %s' %
+                        patch_location_line)
+
+      if empty_line:
+        raise Exception('Last line should be empty')
+
+      if file_delta_line.startswith('+'):
+        actual_file_delta = file_delta_line[1:]
+      else:
+        raise Exception('File delta missing initial + for addition: %s' %
+                        file_delta_line)
+
+      # If this isn't an int, then it raises and the PR isn't mergeable
+      points_change = int(actual_file_delta)
+
+      bonuses.append((points_user, bonus_name, points_change))
+
+    if not bonuses:
+      raise Exception('No bonus files created')
+
+    return bonuses
+
   def author(self) -> str:
     return self._pr_json['user']['login']
 

--- a/rules/0.3-allow-points-transfer.py
+++ b/rules/0.3-allow-points-transfer.py
@@ -17,55 +17,13 @@ def should_allow(pr):
   #  - me:  -1 point
   #  - you: +1 point
 
-  diff = pr.diff()
-  if diff.modified_files or diff.removed_files:
-    raise Exception('All file changes must be additions')
+  bonuses = pr.get_new_bonuses_or_raise()
 
   total_points_change = 0
-
-  for added_file in diff.added_files:
-    s_players, points_user, s_bonuses, bonus_name =  added_file.path.split('/')
-    if s_players != 'players' or s_bonuses != 'bonuses':
-      raise Exception('Added file %s is not a bonus file' % added_file)
-
+  for points_user, points_name, points_change in bonuses:
     if points_user not in util.users():
       raise Exception('Points transfer PRs should not add users: got %s' %
                       points_user)
-
-    (diff_invocation_line, file_mode_line, _, removed_file_line,
-     added_file_line, patch_location_line, file_delta_line,
-     empty_line) = str(added_file).split('\n')
-
-    if diff_invocation_line != 'diff --git a/%s b/%s' % (
-        added_file.path, added_file.path):
-      raise Exception('Unexpected diff invocation: %s' % diff_invocation_line)
-
-    if file_mode_line != 'new file mode 100644':
-      raise Exception('File added with incorrect mode: %s' % file_mode_line)
-
-    if removed_file_line != '--- /dev/null':
-      raise Exception(
-        'Diff format makes no sense: added files should say they are from /dev/null')
-
-    if added_file_line != '+++ b/%s' % added_file.path:
-      raise Exception('Something wrong with file adding line: file is '
-                      '%s but got %s' % (added_file.path, added_file_line))
-
-    if patch_location_line != '@@ -0,0 +1,1 @@':
-      raise Exception('Patch location makes no sense: %s' %
-                      patch_location_line)
-
-    if empty_line:
-      raise Exception('Last line should be empty')
-
-    if file_delta_line.startswith('+'):
-      actual_file_delta = file_delta_line[1:]
-    else:
-      raise Exception('File delta missing initial + for addition: %s' %
-                      file_delta_line)
-
-    # If this isn't an int, then it raises and the PR isn't mergeable
-    points_change = int(actual_file_delta)
 
     if points_change < 0:
       if points_user not in pr.approvals:


### PR DESCRIPTION
In #226 @tnelling is trying to add something to make it easier to add new players, which adds a second use case for "parse a diff, figure out if all changes are additions of bonus files, and if so parse them".  I've now factored this out into `PullRequest.get_new_bonuses_or_raise()` and updated `0.3-allow-points-transfer.py` to use it