### PR TITLE
Make win chance fair with large numbers

### DIFF
--- a/util.py
+++ b/util.py
@@ -55,10 +55,6 @@ def days_since(ts: int) -> int:
 def days_since_last_commit() -> int:
   return days_since(last_commit_ts())
 
-# Sums all points across all users
-def total_points() -> int:
-  sum([total_user_points(user_points) for user_points in get_user_points()])
-
 # Takes a specific user's point values, and computes the total.
 def total_user_points(user_points: Dict[str, int]) -> int:
   return sum(user_points.values())

--- a/util.py
+++ b/util.py
@@ -55,6 +55,10 @@ def days_since(ts: int) -> int:
 def days_since_last_commit() -> int:
   return days_since(last_commit_ts())
 
+# Sums all points across all users
+def total_points() -> int:
+  sum([total_user_points(user_points) for user_points in get_user_points()])
+
 # Takes a specific user's point values, and computes the total.
 def total_user_points(user_points: Dict[str, int]) -> int:
   return sum(user_points.values())

--- a/validate.py
+++ b/validate.py
@@ -116,11 +116,18 @@ def determine_if_winner():
   #   B wins if random is [a_points, a_points + b_points)
   #   C wins if random is [a_points + b_points, a_points + b_points + c_points)
   #   no one wins if random is [a_points + b_points + c_points, 1)
+  #
+  # The number line defaults to a range of 100000.
+  # In order to ensure fairness with large numbers of points,
+  # we extend the line if total points across all players exceed that value.
+  # Relative chance per-player is still preserved.
 
   rnd = util.random()
+  total_points = util.total_points()
+  scalar = min(0.00001, 1.0 / total_points)
   points_so_far = 0
   for user, user_points in util.get_user_points().items():
-    if rnd < 0.00001 * (util.total_user_points(user_points) + points_so_far):
+    if rnd < scalar * (util.total_user_points(user_points) + points_so_far):
       raise Exception('%s wins!' % user)
     points_so_far += util.total_user_points(user_points)
 

--- a/validate.py
+++ b/validate.py
@@ -123,13 +123,23 @@ def determine_if_winner():
   # Relative chance per-player is still preserved.
 
   rnd = util.random()
-  total_points = util.total_points()
+  all_user_points = util.get_user_points()
+
+  summed_user_points = [(user, util.total_user_points(user_points))
+                        for user, user_points in all_user_points.items()]
+
+  # Don't include negative values when summing user points,
+  # since they have no chance to win anyway
+  # There shouldn't be negative values, but just in case...
+  total_points = sum([user_points for user, user_points
+                      in summed_user_points if user_points > 0])
+
   scalar = min(0.00001, 1.0 / total_points)
   points_so_far = 0
-  for user, user_points in util.get_user_points().items():
-    if rnd < scalar * (util.total_user_points(user_points) + points_so_far):
+  for user, user_points in summed_user_points:
+    if rnd < scalar * (user_points + points_so_far):
       raise Exception('%s wins!' % user)
-    points_so_far += util.total_user_points(user_points)
+    points_so_far += user_points
 
   print('The game continues.')
 


### PR DESCRIPTION
Consider the following situation: everyone is at 40000 points. The player order is Jon (John?), Jeff, Pavel, myself. So Jon & Jeff would have a 2/5 chance to win, Pavel would have a 1/5 chance to win, and I'd have no chance to win, despite having the same number of points.

This PR is intended to address the problem by increasing the scalar if the total points exceed 100,000. We preserve our intended initial state of very low chance to win by having 100,000 as a floor, and if only one player accrues a very large number of points, they'll still have a nearly guaranteed win. But if multiple players gain large numbers of points, order will not affect their chance to win.